### PR TITLE
Fix compiling error in MSVC

### DIFF
--- a/include/occ/ints/boys.h
+++ b/include/occ/ints/boys.h
@@ -200,9 +200,12 @@ public:
     static constexpr int N = Order + 1;
 
     static std::unique_ptr<double[], void(*)(double*)> generate() {
+        double* table_ptr = static_cast<double*>(
+            ::operator new[](TableSize * sizeof(double), std::align_val_t{ 64 })
+            );
         auto table = std::unique_ptr<double[], void(*)(double*)>(
-            new (std::align_val_t{64}) double[TableSize],
-            [](double* p) { operator delete[](p, std::align_val_t{64}); }
+            table_ptr,
+            [](double* p) { ::operator delete[](p, std::align_val_t{ 64 }); }
         );
 
         std::array<double, N> nodes;


### PR DESCRIPTION
This pull request updates the memory allocation strategy in the `BoysTableGenerator` class to improve clarity and maintainability. The main change is switching from placement-new allocation to explicit use of the global `operator new[]` with alignment.

Memory allocation improvements:

* Changed the allocation of the table in `BoysTableGenerator::generate()` to use `::operator new[]` with aligned storage, replacing the previous use of placement-new. This clarifies the allocation and deallocation process for aligned arrays.